### PR TITLE
fixed playtest bugs

### DIFF
--- a/Cheese Fighter/Assets/Scenes/FirstStage.unity
+++ b/Cheese Fighter/Assets/Scenes/FirstStage.unity
@@ -1129,7 +1129,7 @@ Rigidbody2D:
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
-  m_Mass: 1
+  m_Mass: 10
   m_LinearDrag: 0
   m_AngularDrag: 0.05
   m_GravityScale: 1

--- a/Cheese Fighter/Assets/Scripts/Environment/MoveablePlatform.cs
+++ b/Cheese Fighter/Assets/Scripts/Environment/MoveablePlatform.cs
@@ -57,7 +57,8 @@ public class MoveablePlatform : MonoBehaviour
     void OnCollisionStay2D(Collision2D col)
     {
         Rat rat = col.gameObject.GetComponent<Rat>();
-        if (rat != null)
+        Transform otherTransform = col.gameObject.transform;
+        if (rat != null && otherTransform.position.y > transform.position.y)
         {
             rat.rb.velocity = rb.velocity;
         }

--- a/Cheese Fighter/Assets/Scripts/Mechanics/Rat.cs
+++ b/Cheese Fighter/Assets/Scripts/Mechanics/Rat.cs
@@ -153,6 +153,8 @@ public class Rat : MonoBehaviour
         rb.velocity = Vector2.zero;
         hp = 0; 
         StopAllCoroutines();
+        action = false;
+        animator.SetTrigger(Return);
         if (lives == 0) 
         {
             GameplayManager.Instance.DecideVictor();


### PR DESCRIPTION
- moving platforms no longer drag along players who're directly under them
- players can no longer shift a moving platform's path by clinging onto their edge
- rats no longer freeze if they die while performing an action